### PR TITLE
Change load_mappings of crates.nvim to init func.

### DIFF
--- a/plugins.lua
+++ b/plugins.lua
@@ -35,7 +35,10 @@ local plugins = {
   },
   {
     'saecki/crates.nvim',
-    ft = {"rust", "toml"},
+    ft = {"toml"},
+    init = function()
+      require("core.utils").load_mappings("crates")
+      end,
     config = function(_, opts)
       local crates  = require('crates')
       crates.setup(opts)
@@ -43,8 +46,7 @@ local plugins = {
         sources = { { name = "crates" }}
       })
       crates.show()
-      require("core.utils").load_mappings("crates")
-    end,
+      end,
   },
   {
     "rust-lang/rust.vim",


### PR DESCRIPTION
On my computer, for the crates.nvim plugin, if I had the mappings in the config func, it wouldn't show me my auto-fills in a .rs file. Moved it to the init func, and now it works, and I think it's more appropriate.

Thanks for the tutorial, I'm starting my nvim journey with this setup and I'm not disliking it for now!
Have a good day, and keep up the good work :)